### PR TITLE
Let URL getters accept a filter instead of query parameters

### DIFF
--- a/src/piArchiveWebserviceProvider.ts
+++ b/src/piArchiveWebserviceProvider.ts
@@ -45,8 +45,7 @@ export class PiArchiveWebserviceProvider {
      * @returns Parameters PI API response
      */
     async getParameters(filter: ParametersFilter): Promise<ParametersResponse> {
-        const queryParameters = filterToParams(filter);
-        const url = this.parametersUrl(queryParameters);
+        const url = this.parametersUrl(filter);
         const res = await this.webservice.getData<ParametersResponse>(url.toString());
         return res.data;
     }
@@ -54,10 +53,11 @@ export class PiArchiveWebserviceProvider {
     /**
      * Construct URL for parameters request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    parametersUrl(queryParameters: string): URL {
+     parametersUrl(filter: ParametersFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/archive/parameters${queryParameters}`,
             this.baseUrl
@@ -71,8 +71,7 @@ export class PiArchiveWebserviceProvider {
      * @returns Locations PI API response
      */
     async getLocations(filter: ArchiveLocationsFilter): Promise<LocationsResponse> {
-        const queryParameters = filterToParams(filter);
-        const url = this.locationsUrl(queryParameters);
+        const url = this.locationsUrl(filter);
         const res = await this.webservice.getData<LocationsResponse>(url.toString());
         return res.data;
     }
@@ -80,13 +79,14 @@ export class PiArchiveWebserviceProvider {
     /**
      * Construct URL for locations request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
+     * @param useArchive whether to use the archive or not
      * @returns complete url for making a request
      */
-    locationsUrl(queryParameters: string): URL {
-        const path = "archive/locations";
+     locationsUrl(filter: ArchiveLocationsFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
-            `${this.baseUrl.pathname}${this.API_ENDPOINT}/${path}${queryParameters}`,
+            `${this.baseUrl.pathname}${this.API_ENDPOINT}/archive/locations${queryParameters}`,
             this.baseUrl
         )
     }
@@ -98,8 +98,7 @@ export class PiArchiveWebserviceProvider {
      * @returns Attributes PI API response
      */
     async getAttributes(filter: AttributesFilter): Promise<AttributesResponse> {
-        const queryParameters = filterToParams(filter);
-        const url = this.attributesUrl(queryParameters);
+        const url = this.attributesUrl(filter);
         const res = await this.webservice.getData<AttributesResponse>(url.toString());
         return res.data;
     }
@@ -107,10 +106,11 @@ export class PiArchiveWebserviceProvider {
     /**
      * Construct URL for attribute request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    attributesUrl(queryParameters: string): URL {
+     attributesUrl(filter: AttributesFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/archive/attributes${queryParameters}`,
             this.baseUrl
@@ -136,8 +136,7 @@ export class PiArchiveWebserviceProvider {
             documentFormat: DocumentFormat.PI_JSON,
         }
         const filterWithDefaults = {...mappedFilter, ...defaults}
-        const queryParameters = filterToParams(filterWithDefaults)
-        const url = this.externalForecastsUrl(queryParameters)
+        const url = this.externalForecastsUrl(filterWithDefaults)
         const res = await this.webservice.getData<ExternalForecastsResponse>(url.toString());
         return res.data;
     }
@@ -145,15 +144,14 @@ export class PiArchiveWebserviceProvider {
     /**
      * Construct URL for external forecast request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    externalForecastsUrl(queryParameters: string): URL {
+     externalForecastsUrl(filter: ExternalForecastsFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/archive/netcdfstorageforecasts${queryParameters}`,
             this.baseUrl
         )
     }
-
-
 }

--- a/src/piWebserviceProvider.ts
+++ b/src/piWebserviceProvider.ts
@@ -44,8 +44,7 @@ export class PiWebserviceProvider {
      * @returns Locations PI API response
      */
     async getLocations(filter: LocationsFilter): Promise<LocationsResponse> {
-        const queryParameters = filterToParams(filter);
-        const url = this.locationsUrl(queryParameters);
+        const url = this.locationsUrl(filter);
         const res = await this.webservice.getData<LocationsResponse>(url.toString());
         return res.data;
     }
@@ -74,8 +73,7 @@ export class PiWebserviceProvider {
             documentFormat: DocumentFormat.PI_JSON,
         }
         const filterWithDefaults = {...defaults, ...filter};
-        const queryParameters = filterToParams(filterWithDefaults);
-        const url = this.timeSeriesUrl(queryParameters);
+        const url = this.timeSeriesUrl(filterWithDefaults);
         if (url.toString().length <= this.maxUrlLength) {
             const res = await this.webservice.getData<TimeSeriesResponse>(url.toString());
             return res.data;
@@ -106,8 +104,7 @@ export class PiWebserviceProvider {
             documentFormat: DocumentFormat.PI_JSON,
         }
         const filterWithDefaults = {...defaults, ...filter};
-        const queryParameters = filterToParams(filterWithDefaults);
-        const url = this.timeSeriesGridUrl(queryParameters);
+        const url = this.timeSeriesGridUrl(filterWithDefaults);
         const res = await this.webservice.getData<TimeSeriesResponse>(url.toString());
         return res.data;
     }
@@ -121,8 +118,7 @@ export class PiWebserviceProvider {
     async getTaskRuns(filter: TaskRunsFilter): Promise<TaskRunsResponse> {
         const defaults: Partial<TaskRunsFilter> = {}
         const filterWithDefaults = {...defaults, ...filter}
-        const queryParameters = filterToParams(filterWithDefaults)
-        const url = this.taskRunsUrl(queryParameters);
+        const url = this.taskRunsUrl(filterWithDefaults);
         const requestInit = {} as RequestInit;
         requestInit.cache = "no-cache";
         const res = await this.webservice.getDataWithRequestInit<TaskRunsResponse>(url.toString(), requestInit);
@@ -162,23 +158,21 @@ export class PiWebserviceProvider {
      * @returns Display groups API response
      */
     async getDisplayGroupsTimeSeriesInfo(filter: DisplayGroupsFilter): Promise<DisplayGroupsResponse> {
-        const queryParameters = filterToParams(filter)
-        const url = this.displayGroupsUrl(queryParameters)
+        const url = this.displayGroupsUrl(filter)
         const res = await this.webservice.getData<DisplayGroupsResponse>(url.toString());
         return res.data;
     }
 
-
     /**
      * Construct URL for locations request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    locationsUrl(queryParameters: string): URL {
-        const path = 'locations';
+    locationsUrl(filter: LocationsFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
-            `${this.baseUrl.pathname}${this.API_ENDPOINT}/${path}${queryParameters}`,
+            `${this.baseUrl.pathname}${this.API_ENDPOINT}/locations${queryParameters}`,
             this.baseUrl
         )
     }
@@ -186,10 +180,11 @@ export class PiWebserviceProvider {
     /**
      * Construct URL for time series request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    timeSeriesUrl(queryParameters: string): URL {
+     timeSeriesUrl(filter: TimeSeriesFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/timeseries${queryParameters}`,
             this.baseUrl
@@ -199,10 +194,11 @@ export class PiWebserviceProvider {
     /**
      * Construct URL for time series grid request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    timeSeriesGridUrl(queryParameters: string): URL {
+     timeSeriesGridUrl(filter: TimeSeriesGridFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/timeseries/grid${queryParameters}`,
             this.baseUrl
@@ -212,10 +208,11 @@ export class PiWebserviceProvider {
     /**
      * Construct URL for display groups request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    displayGroupsUrl(queryParameters: string): URL {
+    displayGroupsUrl(filter: DisplayGroupsFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/displaygroups${queryParameters}`,
             this.baseUrl
@@ -223,12 +220,13 @@ export class PiWebserviceProvider {
     }
 
     /**
-     * Construct URL for task runs request
+     * Construct URL for module run times request
      *
-     * @param queryParameters query string
+     * @param filter an object with request query parameters
      * @returns complete url for making a request
      */
-    taskRunsUrl(queryParameters: string): URL {
+     taskRunsUrl(filter: TaskRunsFilter): URL {
+        const queryParameters = filterToParams(filter)
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/taskruns${queryParameters}`,
             this.baseUrl

--- a/src/piWebserviceProvider.ts
+++ b/src/piWebserviceProvider.ts
@@ -184,19 +184,6 @@ export class PiWebserviceProvider {
     }
 
     /**
-     * Construct URL for parameters request
-     *
-     * @param queryParameters query string
-     * @returns complete url for making a request
-     */
-    parametersUrl(queryParameters: string): URL {
-        return new URL(
-            `${this.baseUrl.pathname}${this.API_ENDPOINT}/archive/parameters${queryParameters}`,
-            this.baseUrl
-        )
-    }
-
-    /**
      * Construct URL for time series request
      *
      * @param queryParameters query string

--- a/src/piWebserviceProvider.ts
+++ b/src/piWebserviceProvider.ts
@@ -143,8 +143,7 @@ export class PiWebserviceProvider {
      * @returns import status API response
      */
     async getImportStatus(): Promise<ImportStatusResponse> {
-        const queryParameters = "documentFormat=PI_JSON"
-        const url = this.importStatusUrl(queryParameters);
+        const url = this.importStatusUrl();
         const requestInit = {} as RequestInit;
         requestInit.cache = "no-cache";
         const res = await this.webservice.getDataWithRequestInit<ImportStatusResponse>(url.toString(), requestInit);
@@ -236,10 +235,10 @@ export class PiWebserviceProvider {
     /**
      * Construct URL for import status request
      *
-     * @param queryParameters query string
      * @returns complete url for making a request
      */
-    importStatusUrl(queryParameters: string): URL {
+    importStatusUrl(): URL {
+        const queryParameters = "documentFormat=PI_JSON"
         return new URL(
             `${this.baseUrl.pathname}${this.API_ENDPOINT}/import/status?${queryParameters}`,
             this.baseUrl


### PR DESCRIPTION
Since these functions are exposed, they are much more useful if they accept a filter, similar to the fetch methods.