### PR TITLE
query parameters without plural 's' on archive/attributes endpoint

### DIFF
--- a/src/requestParameters/attributesFilter.ts
+++ b/src/requestParameters/attributesFilter.ts
@@ -13,12 +13,12 @@ export interface AttributesFilter extends BaseFilter {
      * Subset of locations for which to retrieve parameters.
      * This parameter has to be duplicated to specify multiple locations.
      */
-    locationIds?: string | string[];
+    locationId?: string | string[];
     /**
      * Subset of locations for which to retrieve parameters.
      * This parameter has to be duplicated to specify multiple locations.
      */
-    parameterIds?: string | string[];
+    parameterId?: string | string[];
     /**
      * attribute(key)=value (string): one or more attributes that have to match the archive attribute.
      *  Attributes are passed by passing the key as an argument to the attribute() parameter and the value as parameter value.

--- a/test/unit/archive/attributes.spec.ts
+++ b/test/unit/archive/attributes.spec.ts
@@ -1,5 +1,3 @@
-import {PiWebserviceProvider} from '../../../src/piWebserviceProvider'
-import {ArchiveAttributes} from '../../../src/response'
 import fetchMock from 'fetch-mock';
 import expectedResponse from '../mock/attributes.json'
 import {AttributesFilter} from "../../../src/requestParameters/attributesFilter";
@@ -12,7 +10,7 @@ describe("archive/attributes", function () {
     });
 
     it("gets called when done", async function () {
-        fetchMock.mock('https://mock.dev/fewswebservices/rest/fewspiservice/v1/archive/attributes?documentFormat=PI_JSON&parameterIds=waterlevel_stat_bias&locationIds=delfzijl&attributes=source', {
+        fetchMock.mock('https://mock.dev/fewswebservices/rest/fewspiservice/v1/archive/attributes?documentFormat=PI_JSON&parameterId=waterlevel_stat_bias&locationId=delfzijl&attributes=source', {
             status: 200,
             body: JSON.stringify(expectedResponse)
         });
@@ -21,11 +19,11 @@ describe("archive/attributes", function () {
 
         const filter: AttributesFilter = {
             documentFormat: DocumentFormat.PI_JSON,
-            parameterIds: "waterlevel_stat_bias",
-            locationIds: "delfzijl",
+            parameterId: "waterlevel_stat_bias",
+            locationId: "delfzijl",
             attributes: 'source',
         }
-        const results: ArchiveAttributes = await provider.getAttributes(filter) as ArchiveAttributes;
+        const results = await provider.getAttributes(filter);
         expect("archiveAttributes" in results).toBe(true)
         expect(results.archiveAttributes.length).toBe(5)
         expect(results).toStrictEqual(expectedResponse);


### PR DESCRIPTION
@grijzea: The server implements `parameterId` and `locationId` is this correct?
https://rwsos-dataservices-ont.avi.deltares.nl/matroos/FewsWebServices/rest/fewspiservice/v1/archive/attributes?parameterId=waterlevel&locationId=vlissingen&locationId=lobith&documentFormat=PI_JSON

This is different from other endpoints, where the plural is used `parameterIds` and `locationIds`. 