### PR TITLE
Update dependencies and improve type handling in various modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "@deltares/fews-web-oc-utils": "^2.0.2"
+        "@deltares/fews-web-oc-utils": "^2.1.1"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^12.3.0",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-utils/-/fews-web-oc-utils-2.0.2.tgz",
-      "integrity": "sha512-4nR6q57nanYK7WE+33JS5umQMiqanOI1Xot+XASmi5V9jmszJRLbSEmlYjsPoatyMwlR3WHGSjKuhXldYpzjWQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-utils/-/fews-web-oc-utils-2.1.1.tgz",
+      "integrity": "sha512-Y8XMZTxdCFm+AiQ2IRPobdIh358gX3EJ60sEFXM5AHfienpP3AVA2AatwY8HlsQEI28Vl/jj487/8+oQJyfWNg==",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "sonar": "sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_KEY -Dsonar.projectName='Delft-FEWS Web OC PI Requests'"
   },
   "dependencies": {
-    "@deltares/fews-web-oc-utils": "^2.0.2"
+    "@deltares/fews-web-oc-utils": "^2.1.1"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.3.0",

--- a/scripts/generateTypes.js
+++ b/scripts/generateTypes.js
@@ -199,10 +199,14 @@ const generateTypes = async (schemas) => {
 
 const type = process.argv[2]
 
-if (type === 'pi') {
-  generateTypes(piSchemas)
-} else if (type === 'archive') {
-  generateTypes(archiveSchemas)
-} else {
-  console.error('Invalid argument. Use "pi" or "archive".')
+const run = async () => {
+  if (type === 'pi') {
+    await generateTypes(piSchemas)
+  } else if (type === 'archive') {
+    await generateTypes(archiveSchemas)
+  } else {
+    console.error('Invalid argument. Use "pi" or "archive".')
+  }
 }
+
+await run()

--- a/src/output/parameters/convertToParameterGroups.ts
+++ b/src/output/parameters/convertToParameterGroups.ts
@@ -22,7 +22,7 @@ function isParameter(parameter: Parameter | unknown): parameter is Parameter { /
 function isParameterGroup(
   parameter: ParameterGroup | unknown, // NOSONAR(S6571) - Unknown type in type guard is recommended
 ): parameter is ParameterGroup {
-  return (parameter as ParameterGroup).parameters !== undefined
+  return parameter !== undefined && (parameter as ParameterGroup).parameters !== undefined
 }
 
 function toParameter(parameter: Parameter): Parameter {

--- a/src/output/parameters/convertToParameterGroups.ts
+++ b/src/output/parameters/convertToParameterGroups.ts
@@ -9,7 +9,7 @@ import type { ParameterGroup } from './parameterGroup'
  * @param {Parameter | any} parameter - The value to be checked.
  * @returns {boolean} True if the value is of type Parameter, false otherwise.
  */
-function isParameter(parameter: Parameter | unknown): parameter is Parameter {
+function isParameter(parameter: Parameter | unknown): parameter is Parameter { // NOSONAR(S6571) - Unknown type in type guard is recommended
   return (parameter as Parameter).name !== undefined
 }
 
@@ -20,9 +20,41 @@ function isParameter(parameter: Parameter | unknown): parameter is Parameter {
  * @returns {boolean} True if the value is of type ParameterGroup, false otherwise.
  */
 function isParameterGroup(
-  parameter: ParameterGroup | unknown,
+  parameter: ParameterGroup | unknown, // NOSONAR(S6571) - Unknown type in type guard is recommended
 ): parameter is ParameterGroup {
   return (parameter as ParameterGroup).parameters !== undefined
+}
+
+function toParameter(parameter: Parameter): Parameter {
+  return {
+    id: parameter.id,
+    name: parameter.name,
+    shortName: parameter.shortName,
+  }
+}
+
+function toParameterGroup(parameter: {
+  parameterGroup: string
+  parameterType?: string
+  unit?: string
+  displayUnit?: string
+  usesDatum?: string
+}): ParameterGroup {
+  const parameterGroup: ParameterGroup = {
+    id: parameter.parameterGroup,
+    parameterType:
+      parameter.parameterType === 'instantaneous'
+        ? 'instantaneous'
+        : 'accumulative',
+    unit: parameter.unit ?? '',
+    parameters: [],
+  }
+
+  if (parameter.displayUnit !== parameter.unit)
+    parameterGroup.displayUnit = parameter.displayUnit
+  if (parameter.usesDatum === 'true') parameterGroup.usesDatum = true
+
+  return parameterGroup
 }
 
 /**
@@ -34,55 +66,40 @@ function isParameterGroup(
 export function convertToParameterGroups(
   response: TimeSeriesParametersResponse,
 ): ParameterGroupsOutput {
-  const groupIds: string[] = []
+  const groupsById = new Map<string, ParameterGroup>()
   const result: ParameterGroupsOutput = {
     parameters: [],
   }
+
   for (const tsParameter of response.timeSeriesParameters) {
     const parameterGroupId = tsParameter.parameterGroup
-    if (parameterGroupId !== undefined && groupIds.includes(parameterGroupId)) {
-      const group = result.parameters.find(
-        (g) => 'parameters' in g && g.id === parameterGroupId,
-      )
-      if (isParameterGroup(group) && isParameter(tsParameter)) {
-        const parameter: Parameter = {
-          id: tsParameter.id,
-          name: tsParameter.name,
-          shortName: tsParameter.shortName,
-        }
-        group.parameters.push(parameter)
-      }
-    } else if (parameterGroupId !== undefined) {
-      groupIds.push(parameterGroupId)
-      const parameterGroup: ParameterGroup = {
-        id: parameterGroupId,
-        parameterType:
-          tsParameter.parameterType === 'instantaneous'
-            ? 'instantaneous'
-            : 'accumulative',
-        unit: tsParameter.unit ?? '',
-        parameters: [],
-      }
-      if (tsParameter.displayUnit !== tsParameter.unit)
-        parameterGroup.displayUnit = tsParameter.displayUnit
-      if (tsParameter.usesDatum === 'true') parameterGroup.usesDatum = true
-      if (isParameter(tsParameter)) {
-        const parameter: Parameter = {
-          id: tsParameter.id,
-          name: tsParameter.name,
-          shortName: tsParameter.shortName,
-        }
-        parameterGroup.parameters.push(parameter)
-      }
-      result.parameters.push(parameterGroup)
-    } else if (isParameter(tsParameter)) {
-      const parameter: Parameter = {
-        id: tsParameter.id,
-        name: tsParameter.name,
-        shortName: tsParameter.shortName,
-      }
-      result.parameters.push(parameter)
+
+    if (parameterGroupId === undefined) {
+      if (isParameter(tsParameter)) result.parameters.push(toParameter(tsParameter))
+      continue
     }
+
+    const existingGroup = groupsById.get(parameterGroupId)
+    if (isParameterGroup(existingGroup)) {
+      if (isParameter(tsParameter)) existingGroup.parameters.push(toParameter(tsParameter))
+      continue
+    }
+
+    const parameterGroup = toParameterGroup({
+      parameterGroup: parameterGroupId,
+      parameterType: tsParameter.parameterType,
+      unit: tsParameter.unit,
+      displayUnit: tsParameter.displayUnit,
+      usesDatum: tsParameter.usesDatum,
+    })
+
+    if (isParameter(tsParameter)) {
+      parameterGroup.parameters.push(toParameter(tsParameter))
+    }
+
+    groupsById.set(parameterGroupId, parameterGroup)
+    result.parameters.push(parameterGroup)
   }
+
   return result
 }

--- a/src/piWebserviceProvider.ts
+++ b/src/piWebserviceProvider.ts
@@ -91,17 +91,15 @@ import type { ParameterGroupsOutput } from './output/parameters/parameterGroupsO
 import {absoluteUrl, filterToParams, splitUrl} from "./utils/index.js";
 
 import {DefaultParser, PiRestService, PlainTextParser, RequestOptions} from "@deltares/fews-web-oc-utils";
-import type { ResponseParser, TransformRequestFunction } from "@deltares/fews-web-oc-utils";
-// @ts-expect-error Cannot find module
-import type { DataRequestResult } from "@deltares/fews-web-oc-utils";
+import type { ResponseParser, TransformRequestFunction, DataRequestResult } from "@deltares/fews-web-oc-utils";
 import { DynamicReportDisplayCapabilitiesFilter, DynamicReportDisplayFilter } from './requestParameters/dynamicDisplayReportFilter'
 import { DocumentDisplaysResponse } from './response/documentdisplays'
 import { DocumentDisplaysFilter } from './requestParameters/documentDisplaysFilter'
 import { MicroFrontEndsFilter } from './requestParameters/microFrontEndsFilter.js'
 
 export class PiWebserviceProvider {
-    private _baseUrl: URL
-    maxUrlLength: number
+    private readonly _baseUrl: URL
+    private readonly maxUrlLength: number
     private readonly explodeQueryParameters: boolean
     readonly API_ENDPOINT = 'rest/fewspiservice/v1';
     webservice: PiRestService;
@@ -1483,11 +1481,7 @@ export class PiWebserviceProvider {
     }
 
     postWhatIfScenarioUrl(filter: PostWhatIfScenarioFilter): URL {
-        const queryParameters = this.buildQueryParams(filter)
-        return new URL(
-            `${this._baseUrl.pathname}${this.API_ENDPOINT}/whatifscenarios${queryParameters}`,
-            this._baseUrl
-        )
+        return this.whatIfScenariosUrl(filter)
     }
 
     componentSettingsUrl(filter: ComponentSettingsFilter): URL {
@@ -1577,11 +1571,7 @@ export class PiWebserviceProvider {
     }
 
     postUserSettingsUrl(filter: PostUserSettingsFilter): URL {
-        const queryParameters = this.buildQueryParams(filter)
-        return new URL(
-            `${this._baseUrl.pathname}${this.API_ENDPOINT}/usersettings${queryParameters}`,
-            this._baseUrl
-        )
+        return this.userSettingsUrl(filter)
     }
 
     userSettingsUsersUrl(filter: UserSettingsUsersFilter): URL {

--- a/src/requestParameters/moduleRunTimesFilter.ts
+++ b/src/requestParameters/moduleRunTimesFilter.ts
@@ -1,9 +1,12 @@
 import type { BaseFilter } from "./baseFilter";
 
 export interface ModuleRuntimesFilter extends BaseFilter {
+    /**
+     * Filter module run time with the specified workflowId
+     */
     workflowId?: string;
-
-    // TODO: Is this being used? Seems to be an invalid parameter.
-    // Unique sequence number that can be used to order asynchronous api requests.
-    draw?: number;
+    /**
+     * Include manual tasks in the filter
+     */
+    includeManualTasks: boolean;
 }

--- a/src/requestParameters/runTaskFilter.ts
+++ b/src/requestParameters/runTaskFilter.ts
@@ -26,10 +26,9 @@ export interface RunTaskFilter extends BaseFilter {
      */
     scenarioId?: string;
     /**
-     * User id of the user that runs the task.
-     * TODO: not optional according to the documentation
-     */
-    userId?: string;
+     * User id of the user that runs the task. 
+     */ 
+    userId: string;
     /**
      * Descriptive text to identify run.
      */

--- a/src/requestParameters/timeSeriesGridMaxValuesFilter.ts
+++ b/src/requestParameters/timeSeriesGridMaxValuesFilter.ts
@@ -1,12 +1,10 @@
-// FIXME: We are currently not extending from `BaseFilter`, because the endpoint
-//        does not accept documentFormat as a query parameter, despite being
-//        documented as such. If this is fixed, we should extend from
-//        `BaseFilter`.
-export interface TimeSeriesGridMaxValuesFilter {
-   // Start time of search period that looks for timeseries values that are
-   // within this period. If the start time doesn't match a timestamp of the
-   // time series, the closest timestamp before the startTime, will also be
-   // returned. Format: yyyy-MM-ddTHH:mm:ssZ
+import { BaseFilter } from './baseFilter'
+
+export interface TimeSeriesGridMaxValuesFilter extends BaseFilter {
+  // Start time of search period that looks for timeseries values that are
+  // within this period. If the start time doesn't match a timestamp of the
+  // time series, the closest timestamp before the startTime, will also be
+  // returned. Format: yyyy-MM-ddTHH:mm:ssZ
   startTime: string
   // End time of search period that looks for timeseries values that are within
   // this period. If the endTime doesn't match a timestamp of the time series,
@@ -27,4 +25,8 @@ export interface TimeSeriesGridMaxValuesFilter {
   // attachment. Can be used in the testpage to avoid the response being
   // rendered in the browser.
   downloadAsFile?: string
+  // Time value of external forecast time. If startTime and endTime are not set, the complete forecast will be read. Format: yyyy-MM-ddTHH:mm:ssZ
+  externalForecastTime?: string
+  // Task run id of the task run to retrieve
+  taskRunId?: string
 }

--- a/src/utils/webOcCompontentsTypeGuards.ts
+++ b/src/utils/webOcCompontentsTypeGuards.ts
@@ -2,41 +2,35 @@ import {
   WebOcSchematicStatusDisplayConfig,
   WebOcSpatialDisplayConfig,
   WebOcSystemMonitorConfig,
-  WebOcTopologyDisplayConfig
-} from "../response";
+  WebOcTopologyDisplayConfig,
+} from '../response'
 
-export function isSchematicStatusDisplay(component: (
-    | WebOcSpatialDisplayConfig
-    | WebOcSchematicStatusDisplayConfig
-    | WebOcSystemMonitorConfig
-    | WebOcTopologyDisplayConfig
-    )): component is WebOcSchematicStatusDisplayConfig {
-  return component.type === 'SchematicStatusDisplay';
+type WebOcComponentConfig =
+  | WebOcSpatialDisplayConfig
+  | WebOcSchematicStatusDisplayConfig
+  | WebOcSystemMonitorConfig
+  | WebOcTopologyDisplayConfig
+
+export function isSchematicStatusDisplay(
+  component: WebOcComponentConfig,
+): component is WebOcSchematicStatusDisplayConfig {
+  return component.type === 'SchematicStatusDisplay'
 }
 
-export function isTopologyDisplay(component: (
-    | WebOcSpatialDisplayConfig
-    | WebOcSchematicStatusDisplayConfig
-    | WebOcSystemMonitorConfig
-    | WebOcTopologyDisplayConfig
-    )): component is WebOcTopologyDisplayConfig {
-  return component.type === 'TopologyDisplay';
+export function isTopologyDisplay(
+  component: WebOcComponentConfig,
+): component is WebOcTopologyDisplayConfig {
+  return component.type === 'TopologyDisplay'
 }
 
-export function isSpatialDisplay(component: (
-    | WebOcSpatialDisplayConfig
-    | WebOcSchematicStatusDisplayConfig
-    | WebOcSystemMonitorConfig
-    | WebOcTopologyDisplayConfig
-    )): component is WebOcSpatialDisplayConfig {
-  return component.type === 'SpatialDisplay';
+export function isSpatialDisplay(
+  component: WebOcComponentConfig,
+): component is WebOcSpatialDisplayConfig {
+  return component.type === 'SpatialDisplay'
 }
 
-export function isSystemMonitor(component: (
-    | WebOcSpatialDisplayConfig
-    | WebOcSchematicStatusDisplayConfig
-    | WebOcSystemMonitorConfig
-    | WebOcTopologyDisplayConfig
-    )): component is WebOcSystemMonitorConfig {
-  return component.type === 'SystemMonitor';
+export function isSystemMonitor(
+  component: WebOcComponentConfig,
+): component is WebOcSystemMonitorConfig {
+  return component.type === 'SystemMonitor'
 }

--- a/test/unit/fews/whatIfScenarios.spec.ts
+++ b/test/unit/fews/whatIfScenarios.spec.ts
@@ -45,7 +45,7 @@ describe("whatIfScenarios", function () {  it("gets called when done", async () 
 
     const results = await provider.getWhatIfScenarios(filter);
     expect(results).toEqual(expectedResponse);
-    expect(results.whatIfScenarioDescriptors.length).toBe(2);
+    expect(results.whatIfScenarioDescriptors).toHaveLength(2);
     expect(results.whatIfScenarioDescriptors[0].id).toBe("id1");
     expect(results.whatIfScenarioDescriptors[0].name).toBe("triple_the_surge");
     expect(results.whatIfScenarioDescriptors[0].whatIfTemplateId).toBe(


### PR DESCRIPTION
- Bump @deltares/fews-web-oc-utils to version 2.1.1 in package.json and package-lock.json
- Refactor generateTypes.js to use async/await for better readability
- Enhance convertToParameterGroups.ts with new utility functions for parameter handling
- Modify request parameter interfaces to include necessary fields and improve type safety
- Clean up type guards in webOcCompontentsTypeGuards.ts for consistency
- Update unit tests for whatIfScenarios to use more descriptive assertions